### PR TITLE
Bump typescript from 5.3.3 to 5.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,11 +20,11 @@
         "prettier": "^3.0.1",
         "prettier-plugin-organize-imports": "^3.2.2",
         "typedoc": "^0.25.0",
-        "typescript": "^5.1.3",
+        "typescript": "^5.4.1",
         "vitest": "^1.2.2"
       },
       "peerDependencies": {
-        "pixi.js": "^8.0.0"
+        "pixi.js": "^8.0.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -6491,9 +6491,9 @@
       }
     },
     "node_modules/pixi.js": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-8.0.1.tgz",
-      "integrity": "sha512-SGtkod644kb/k+hTvSSk9ywpmvgdjiX+gK6NF8He1xyQ0XCRn5ZqN37EPEBsg0ffadjZ40mqtO+2oXyEOLrWzw==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-8.0.2.tgz",
+      "integrity": "sha512-E4oHF+cIkHB1BUHka8jKRih3ywDAKt/uRaTNIm4+7rEWMX5LhZZVryp8bcx516ZyQ8VrpBOs5ohrEViqYhCDAw==",
       "peer": true,
       "dependencies": {
         "@pixi/colord": "^2.9.6",
@@ -8263,9 +8263,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
+      "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -37,11 +37,11 @@
     "prettier": "^3.0.1",
     "prettier-plugin-organize-imports": "^3.2.2",
     "typedoc": "^0.25.0",
-    "typescript": "^5.1.3",
+    "typescript": "^5.4.1",
     "vitest": "^1.2.2"
   },
   "peerDependencies": {
-    "pixi.js": "^8.0.0"
+    "pixi.js": "^8.0.2"
   },
   "scripts": {
     "test": "vitest --run",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     "paths": {
       "mini-signals": ["./node_modules/resource-loader/typings/mini-signals.d.ts"]
     },
-    "strict": true
+    "strict": true,
+    "skipLibCheck": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "**/*.spec.ts"]


### PR DESCRIPTION
https://github.com/pixijs/pixijs/issues/9765
この問題が発生しているため、skipLibCheckオプションを有効にしている