### PR TITLE
chore : add pixi.js to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "husky": "^9.0.10",
         "jsdom": "^24.0.0",
         "lint-staged": "^15.0.1",
+        "pixi.js": "^8.2.5",
         "prettier": "^3.0.1",
         "prettier-plugin-organize-imports": "^4.0.0",
         "typedoc": "^0.26.2",
@@ -2247,7 +2248,7 @@
       "version": "2.9.6",
       "resolved": "https://registry.npmjs.org/@pixi/colord/-/colord-2.9.6.tgz",
       "integrity": "sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -2514,13 +2515,13 @@
       "version": "0.0.12",
       "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.12.tgz",
       "integrity": "sha512-x2tZZYkSxXqWvTDgveSynfjq/T2HyiZHXb00j/+gy19yp70PHCizM48XFdjBCWH7eHBD0R5i/pw9yMBP/BH5uA==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/earcut": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-2.1.4.tgz",
       "integrity": "sha512-qp3m9PPz4gULB9MhjGID7wpo3gJ4bTGXm7ltNDsmOvsPduTeHp8wSW9YckBj3mljeOh4F0m2z/0JKAALRKbmLQ==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/eslint": {
       "version": "8.56.2",
@@ -2839,13 +2840,13 @@
       "version": "0.1.40",
       "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.40.tgz",
       "integrity": "sha512-/BBkHLS6/eQjyWhY2H7Dx5DHcVrS2ICj9owvSRdgtQT6KcafLZA86tPze0xAOsd4FbsYKCUBUQyNi87q7gV7kw==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.10",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
       "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">=10.0.0"
       }
@@ -4022,7 +4023,7 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
       "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
-      "peer": true
+      "dev": true
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -5129,7 +5130,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
       "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==",
-      "peer": true
+      "dev": true
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -6314,7 +6315,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
       "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
-      "peer": true
+      "dev": true
     },
     "node_modules/parse5": {
       "version": "7.1.2",
@@ -6443,10 +6444,10 @@
       }
     },
     "node_modules/pixi.js": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-8.0.5.tgz",
-      "integrity": "sha512-4v88YaMNg0/APoTnje0MFDQt5S7nRM6/yvrZkIxIgqgjs7zMIaxpOl2UDDUDXj/XwdD5lKJAz/H7rVukOepwyQ==",
-      "peer": true,
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-8.2.5.tgz",
+      "integrity": "sha512-cpN4f4Duj2mDPQeDQJQ33LXA8wIGMpWbhld1SklEwESRULYPUsY84zXC8B+Cyl+zojcXH7eY1OMEdbbIPMb+rA==",
+      "dev": true,
       "dependencies": {
         "@pixi/colord": "^2.9.6",
         "@types/css-font-loading-module": "^0.0.12",
@@ -6463,7 +6464,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "peer": true
+      "dev": true
     },
     "node_modules/pkg-dir": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "husky": "^9.0.10",
     "jsdom": "^24.0.0",
     "lint-staged": "^15.0.1",
+    "pixi.js": "^8.2.5",
     "prettier": "^3.0.1",
     "prettier-plugin-organize-imports": "^4.0.0",
     "typedoc": "^0.26.2",


### PR DESCRIPTION
dependabotが更新可能なように、pixi.jsをdevDependenciesに追加。dependabotはpeerDependenciesの監視を行わないため。