### PR TITLE
fix: remove Code Climate badges from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE)
 [![CI](https://github.com/MasatoMakino/pixijs-basic-button/actions/workflows/ci_main.yml/badge.svg)](https://github.com/MasatoMakino/pixijs-basic-button/actions/workflows/ci_main.yml)
-[![Maintainability](https://api.codeclimate.com/v1/badges/53987c65647c8bb04eba/maintainability)](https://codeclimate.com/github/MasatoMakino/pixijs-basic-button/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/53987c65647c8bb04eba/test_coverage)](https://codeclimate.com/github/MasatoMakino/pixijs-basic-button/test_coverage)
 
 [![ReadMe Card](https://github-readme-stats.vercel.app/api/pin/?username=MasatoMakino&repo=pixijs-basic-button)](https://github.com/MasatoMakino/pixijs-basic-button)
 


### PR DESCRIPTION
This pull request makes a minor update to the `README.md` file by removing the Code Climate maintainability and test coverage badges. This simplifies the badge section and removes references to Code Climate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Removed Code Climate Maintainability and Test Coverage badges from the README to simplify the project header.
  - Clarifies presentation without altering any instructions or examples.
  - No impact on functionality, performance, or user workflows.
  - No changes to public APIs or configurations.
  - Safe to upgrade with no action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->